### PR TITLE
Tidy up

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         gccdefault_coverage:
           CMAKE_VARIANT: Debug
-          CXXFLAGS: '-fprofile-arcs --coverage'
+          CXXFLAGS: '-Wall -Wextra -Wconversion -pedantic -fprofile-arcs --coverage'
           CXX: g++
           CC: gcc
           SKIP_COVERAGE: 'false'
@@ -17,28 +17,33 @@ jobs:
           CMAKE_VARIANT: Debug
           CXX: g++-7
           CC: gcc-7
+          CXXFLAGS: -Wall -Wextra -Wconversion -pedantic
         gcc8release:
           CMAKE_VARIANT: Release
           CXX: g++-8
           CC: gcc-8
+          CXXFLAGS: -Wall -Wextra -Wconversion -pedantic
         gcc8asan:
           CMAKE_VARIANT: Debug
           CXX: g++-8
           CC: gcc-8
           SANITIZE: On
+          CXXFLAGS: -Wall -Wextra -Wconversion -pedantic
         clangdebug:
           CMAKE_VARIANT: Debug
           CXX: clang++
           CC: clang
+          CXXFLAGS: -Wall -Wextra -Wconversion -pedantic
         clangasan:
           CMAKE_VARIANT: Debug
           CXX: clang++
           CC: clang
-          CXXFLAGS: -fsanitize=address,undefined -pthread
+          CXXFLAGS: -Wall -Wextra -Wconversion -pedantic -fsanitize=address,undefined -pthread
         clangrelease:
           CMAKE_VARIANT: Release
           CXX: clang++
           CC: clang
+          CXXFLAGS: -Wall -Wextra -Wconversion -pedantic
     steps:
       - script: sudo modprobe vcan && sudo tools/create_vcans.sh vcan0 vcan1 || echo "May fail if they exist already"
         displayName: 'Create virtual CAN interfaces'

--- a/include/canary/basic_endpoint.hpp
+++ b/include/canary/basic_endpoint.hpp
@@ -100,8 +100,4 @@ private:
 
 } // namespace canary
 
-#ifndef CANARY_SEPARATE_COMPILATION
-#include <canary/impl/interface_index.ipp>
-#endif // CANARY_SEPARATE_COMPILATION
-
 #endif // CANARY_BASIC_ENDPOINT_HPP

--- a/tests/frame_header.cpp
+++ b/tests/frame_header.cpp
@@ -10,6 +10,7 @@
 // Test if header is self-contained
 #include <canary/frame_header.hpp>
 
+#include <array>
 #include <boost/core/lightweight_test.hpp>
 #include <linux/can.h>
 
@@ -25,7 +26,8 @@ test_layout()
         std::array<std::uint8_t, 8> data;
     } f{};
     ::can_frame cf;
-    static_assert(sizeof(f) == sizeof(cf));
+    static_assert(sizeof(f) == sizeof(cf),
+                  "Frame header layout must match native can_frame struct.");
 
     f.fh.id(0x1EAD);
     BOOST_TEST_EQ(f.fh.id(), 0x1EAD);

--- a/tests/raw.cpp
+++ b/tests/raw.cpp
@@ -11,6 +11,7 @@
 #include <canary/raw.hpp>
 
 #include <boost/core/lightweight_test.hpp>
+#include <canary/interface_index.hpp>
 
 namespace
 {


### PR DESCRIPTION
- Remove redundant include.
- Enable warnings and pedantic mode in CI.
- Fixup C++11/14 compatibility in tests.