### PR TITLE
Remove sanitizer build option from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(canary VERSION 1 LANGUAGES CXX)
 
-# TODO: This should be in a toolchain file
-option(CANARY_SANITIZE "Build canary tests and examples with address & undefined sanitization enabled" OFF)
-if (CANARY_SANITIZE)
-    message(STATUS "canary: address & undefined sanitizers enabled")
-    add_compile_options(-fsanitize=address,undefined)
-    link_libraries(-fsanitize=address,undefined)
-endif()
-
 # TODO: Don't require Boost if ASIO standalone option is required
 find_package(Boost 1.70
              COMPONENTS

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,7 @@ jobs:
           CMAKE_VARIANT: Debug
           CXX: g++-8
           CC: gcc-8
-          SANITIZE: On
-          CXXFLAGS: -Wall -Wextra -Wconversion -pedantic
+          CXXFLAGS: -Wall -Wextra -Wconversion -pedantic -fsanitize=address,undefined
         clangdebug:
           CMAKE_VARIANT: Debug
           CXX: clang++
@@ -47,7 +46,7 @@ jobs:
     steps:
       - script: sudo modprobe vcan && sudo tools/create_vcans.sh vcan0 vcan1 || echo "May fail if they exist already"
         displayName: 'Create virtual CAN interfaces'
-      - script: cmake -GNinja -H. -Bbuild -DCANARY_SANITIZE=$SANITIZE -DCMAKE_TOOLCHAIN_FILE="~/vcpkg/scripts/buildsystems/vcpkg.cmake" -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);-header-filter=$(pwd)/include/\*" -DCMAKE_BUILD_TYPE=$CMAKE_VARIANT
+      - script: cmake -GNinja -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE="~/vcpkg/scripts/buildsystems/vcpkg.cmake" -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);-header-filter=$(pwd)/include/\*" -DCMAKE_BUILD_TYPE=$CMAKE_VARIANT
         displayName: 'Configure'
       - script: cmake --build build
         displayName: Build


### PR DESCRIPTION
These flags should be set by either a toolchain file or by passing CXXFLAGS.