### PR TITLE
Fix coverage collection reporting

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         gccdefault_coverage:
           CMAKE_VARIANT: Debug
-          CXXFLAGS: '-Wall -Wextra -Wconversion -pedantic -fprofile-arcs --coverage'
+          CXXFLAGS: '-Wall -Wextra -Wconversion -pedantic -fprofile-arcs -fkeep-inline-functions --coverage'
           CXX: g++
           CC: gcc
           SKIP_COVERAGE: 'false'


### PR DESCRIPTION
lcov did not count unused inline functions, causing the coverage count to be higher than it actually was.