### PR TITLE
Add option for building examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,16 @@ target_link_libraries(
 target_compile_features(canary INTERFACE cxx_std_11)
 
 include(CTest)
-option(CANARY_BUILD_COROUTINE_EXAMPLES "Build examples using C++20 coroutines." OFF)
 if(BUILD_TESTING)
     enable_testing()
     add_subdirectory(tests)
 endif()
 
-add_subdirectory(examples)
+option(CANARY_BUILD_EXAMPLES "Build examples." OFF)
+option(CANARY_BUILD_COROUTINE_EXAMPLES "Build examples using C++20 coroutines." OFF)
+if(CANARY_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
 
 
 include(GNUInstallDirs)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       - script: sudo modprobe vcan && sudo tools/create_vcans.sh vcan0 vcan1 || echo "May fail if they exist already"
         displayName: 'Create virtual CAN interfaces'
-      - script: cmake -GNinja -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE="~/vcpkg/scripts/buildsystems/vcpkg.cmake" -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);-header-filter=$(pwd)/include/\*" -DCMAKE_BUILD_TYPE=$CMAKE_VARIANT
+      - script: cmake -GNinja -H. -Bbuild -DCMAKE_TOOLCHAIN_FILE="~/vcpkg/scripts/buildsystems/vcpkg.cmake" -DCMAKE_CXX_CLANG_TIDY="$(which clang-tidy);-header-filter=$(pwd)/include/\*" -DCMAKE_BUILD_TYPE=$CMAKE_VARIANT -DCANARY_BUILD_EXAMPLES=ON
         displayName: 'Configure'
       - script: cmake --build build
         displayName: Build


### PR DESCRIPTION
This avoid building examples when the library is consumed via vcpkg.