### PR TITLE
Fix C++ version check

### DIFF
--- a/include/canary/detail/config.hpp
+++ b/include/canary/detail/config.hpp
@@ -24,13 +24,13 @@
 #endif // CANARY_DECL
 #endif // CANARY_SEPARATE_COMPILATION
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 202002L
 #if __has_include(<span>)
 #ifndef CANARY_HAS_STD_SPAN
 #define CANARY_HAS_STD_SPAN
 #endif // CANARY_HAS_STD_SPAN
 #endif // __has_include(<span>)
-#endif // __cplusplus >= 201703L
+#endif // __cplusplus >= 202002L
 
 #ifdef CANARY_STANDALONE_ASIO
 


### PR DESCRIPTION
Fixed a check for C++20 that incorrectly attempted to include span in
C++17.

Closes: #18

Signed-off-by: Damian Jarek <damian.jarek93gmail.com>